### PR TITLE
Build lbclient on all architectures

### DIFF
--- a/lbclient.spec.tpl
+++ b/lbclient.spec.tpl
@@ -24,7 +24,6 @@ BuildRequires: policycoreutils-python
 %else
 BuildRequires: policycoreutils-python-utils
 %endif
-ExclusiveArch: x86_64
 Requires: net-snmp
 
 %description


### PR DESCRIPTION
In particular we want an aarch64 build.